### PR TITLE
Burp2ivil

### DIFF
--- a/bin/burp2ivil
+++ b/bin/burp2ivil
@@ -27,8 +27,6 @@ use Carp;
 use XML::Simple;
 use Data::Dumper;
 
-use Digest::MD5 qw(md5_base64);
-
 my (
 	$scanname,
 	$scanner,
@@ -105,6 +103,7 @@ $number = 0;
 foreach my $issue ( @{$burp->{issue}}) {
 
 	my $finding = {};
+	#get the IP and the Hostname from the burp export
         my $ip = $issue->{host}->{ip};
         my $hostname = $issue->{host}->{content};
         
@@ -123,13 +122,16 @@ foreach my $issue ( @{$burp->{issue}}) {
                 die "Unknown severity";
         } 
 
-        #Find the port, check hostname. if more than one :, the url contains
-	#a port. Otherwise use the protocol identifier. 
+        #find the port
         my $port;
+	#if : occurs more than once..
+ 	my @amount = $hostname =~ /:/g;
         my $count = () = $hostname =~ /:/g;
         if ( $count > 1)  {
+		#port defined at the end of the hostname, we use that
  		$port= substr $hostname, rindex($hostname, ':')+1;
 	} else {
+		#look at the protocol instead
 		if (index($hostname, 'http://') != -1) {
 			$port = 80;
 		} elsif (index($hostname, 'https://') != -1) {
@@ -139,21 +141,27 @@ foreach my $issue ( @{$burp->{issue}}) {
 
 	#now we fill the finding_txt 
 	my $txt ="";	
+	
 	$txt = join ("", $txt, "Name: ", $issue -> {name}, "\n\nPath: $hostname", $issue ->{path}, "\nLocation: $hostname", $issue->{location}, "\n\nConfidence: ", $issue->{confidence});
         $txt = join ("", $txt,"\n\nIssue Background: ", $issue->{issueBackground}, "\n\nRemediation: ", $issue->{remediationBackground});
 
-	#the ID needs to be only once per finding, but the same between scans
-        #$issue->{id} is not good, because multiple findings can have that same id
-        #so lets make up something
-	# lets get the type (multiple per scan) and add to it, the location..
-	my $scanID = $issue->{type} . md5_base64($issue->{location});
+	#The IP (hostname) /or/ PluginID needs to be unique. Since Burp Suite can have multiple findings with the same ID on different URL's we instead use fill the IP (host) field
+	#with the hostname + the location. This does look ugly with long URL's in the findings tab though.
+	$finding->{ip} = $hostname . $issue->{location};
 
-        $finding->{ip} =  $issue->{host}->{ip};        
-	$finding->{id} = $scanID;
+	#add the finding ID
+	$finding->{id} = $issue->{type};
+	#add severity to finding
 	$finding->{severity} = $severity;
+	#add port to finding
 	$finding->{port} = $port;
+	#add finding_txt to finding
 	$finding->{finding} = $txt;
         
+	#debug: dump the $finding
+        #print "\n";
+	#print Dumper($finding);
+	
 	#write to ivil
 	print OUT ivil_finding($finding);
 } 
@@ -203,4 +211,5 @@ Arguments:
 ";
 	exit();
 }
+
 


### PR DESCRIPTION
Convert Burp Suite Pro's "Scanner -> Results" XML export to ivil, for import into Seccubus.

Only concern is how I handled the ID, since this needs to be reasonable unique and Burp Suite has no such thing. I decided to take the Finding ID  (an ID for example for reflected XSS) and add an md5 hash of the Location to it so that we end up with something that is, for all uses and purposes, unique per scan yet still will be end up as the same value with a rescan (as long as the Location doesn't change obviously).
