### PR TITLE
Quick and dirty password masking in "Manage scans"

### DIFF
--- a/json/getScans.pl
+++ b/json/getScans.pl
@@ -41,13 +41,22 @@ if (not (defined ($workspace_id))) {
 eval {
 	my @data;
 	my $scans = get_scans($workspace_id);
-
+        my $paramline;
 	foreach my $row ( @$scans ) {
+		$paramline = $$row[3];
+		my $wanted;
+                if (index($paramline,'-p ') != -1) {
+                   ($wanted) = $paramline =~ /-p(.*) --policy/;
+		   $paramline =~ s/$wanted/ \[maskedpassword\]/;
+ 		} elsif (index($paramline,'--pw ') != -1) {
+                   ($wanted) = $paramline =~ /--pw(.*) --rc/;
+                   $paramline =~ s/$wanted/ \[maskedpassword\]/;
+		}
 		push (@data, {
 			'id'		=> $$row[0],
 			'name'		=> $$row[1],
 			'scanner'	=> $$row[2],
-			'parameters'	=> $$row[3],
+			'parameters'	=> $paramline,
 			'lastScan'	=> $$row[4],
 			'runs'		=> $$row[5],
 			'findCount'	=> $$row[6],
@@ -66,3 +75,4 @@ sub bye($) {
 	print $json->pretty->encode([{ error => $error }]);
 	exit;
 }
+


### PR DESCRIPTION
Quick fix for: https://github.com/schubergphilis/Seccubus_v2/issues/105 to prevent the password from showing in the "Manage scans" window.

What I did was change /json/getScans.pl so that if sees a parameter line with "-p (._) --policy" or "--pw (._) --rc" it replaces the password with the string [maskedpassword]. This does meant that if you edit it, you will have to re-enter the password!

Also since it's quick and dirty it does not work if you start changing the parameter order/names. This works for me..so good enough ;)
