### PR TITLE
Added parameters max_checks and max_hosts to limit ressource usage during scans

### DIFF
--- a/scanners/OpenVAS6/defaults.txt
+++ b/scanners/OpenVAS6/defaults.txt
@@ -1,1 +1,1 @@
---server='<OpenVAS IP>' --user=<OpenVAS user> --password='$PASSWORD' --policy='Full and fast ultimate' --targetip='$HOSTS' --portlist='All TCP' --quiet
+--server='127.0.0.1' --user=seccubus  --password='$PASSWORD' --policy='Full and fast ti8m' --targetip='$HOSTS' --portlist='All TCP' --quiet

--- a/scanners/OpenVAS6/defaults.txt
+++ b/scanners/OpenVAS6/defaults.txt
@@ -1,1 +1,1 @@
---server='127.0.0.1' --user=seccubus  --password='$PASSWORD' --policy='Full and fast ti8m' --targetip='$HOSTS' --portlist='All TCP' --quiet
+--server='127.0.0.1' --user=seccubus  --password='$PASSWORD' --policy='Full and fast' --targetip='$HOSTS' --portlist='All TCP' --quiet

--- a/scanners/OpenVAS6/help.html
+++ b/scanners/OpenVAS6/help.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2016 Fabien Guillaume, Frank Breedijk, Bernd Leinfelder
+Copyright 2016-2019 Fabien Guillaume, Frank Breedijk, Bernd Leinfelder
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/scanners/OpenVAS6/help.html
+++ b/scanners/OpenVAS6/help.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2016-2019 Fabien Guillaume, Frank Breedijk, Bernd Leinfelder
+Copyright 2014-2019 Fabien Guillaume, Frank Breedijk, Bernd Leinfelder
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/scanners/OpenVAS6/help.html
+++ b/scanners/OpenVAS6/help.html
@@ -27,6 +27,7 @@ Usage: scan     --workspace=&lt;seccubus workspace&gt; --scan=&lt;seccubus scan&
 		        --policy=&lt;OpenVAS Scan Config name&gt; [--target=&lt;OpenVAS target&gt;]
 		        [--targetip=&lt;IP(s) to scan&gt;] [--portlist=&lt;OpenVAS port listname&gt;]
 		        [--portrange=&lt;Port range(s) to scan&gt;] [--sleep=&lt;sleeptime&gt;]
+		        [--maxchecks=&lt;max checks&gt;] [--maxhosts=&lt;max hosts&gt;]
 		        [--timeout=&lt;timeout&gt;] [--nodelete] [--verbose] [--quiet] [--help]
 <p>
 <br><br>
@@ -53,6 +54,10 @@ Parameters description :
 	                is specified and it exists)
 <li>--sleep           - Seconds to sleep between polls of the API  (optional, 
 	                default=10) 
+<li>--maxchecks       - The number of plugins that will run against each host at the
+                        same time (optional, default=4)
+<li>--maxhosts        - The maximum number of hosts to test at the same time
+                        (optional, default=10)
 <li>--timeout         - # Seconds after which to abort a scan (optional, 
 	                default=14400 (4 hours))
 <li>--nodelete        - Don't erase temporary files

--- a/scanners/OpenVAS6/help.html
+++ b/scanners/OpenVAS6/help.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2016 Fabien Guillaume, Frank Breedijk
+Copyright 2016 Fabien Guillaume, Frank Breedijk, Bernd Leinfelder
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/scanners/OpenVAS6/scan
+++ b/scanners/OpenVAS6/scan
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright 2017-2019 Fabien Guillaume, Frank Breedijk, Andrey Danin, Floris Kraak, Alireza Karbasian, Bernd Leinfelder
+# Copyright 2014-2019 Fabien Guillaume, Frank Breedijk, Andrey Danin, Floris Kraak, Alireza Karbasian, Bernd Leinfelder
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scanners/OpenVAS6/scan
+++ b/scanners/OpenVAS6/scan
@@ -43,6 +43,8 @@ my (
 	$portlist,
 	$portlistname,
 	$timeout,
+	$maxchecks,
+	$maxhosts,
 	$verbose,
 	$scan,
 	$timestamp,
@@ -77,6 +79,8 @@ GetOptions (
 	'portrange=s'		=> \$portlist,
 	'sleep=s'			=> \$sleep,
 	'timeout=s' 		=> \$timeout,
+	'maxchecks=s'		=> \$maxchecks,
+	'maxhosts=s'		=> \$maxhosts,
 	'nodelete'			=> \$nodelete,
 	'verbose|v+'		=> \$verbose,
 	'quiet|q!'			=> \$quiet,
@@ -91,6 +95,8 @@ $verbose = 0 if $quiet;
 $targetname=$targetip unless $targetname;
 $portlistname=$portlist unless $portlistname;
 $timeout=14400 unless $timeout;
+$maxchecks=4 unless $maxchecks;
+$maxhosts=10 unless $maxhosts;
 
 help("You must specify a policy") unless $policy;
 help("You must specify a user") unless $user;
@@ -219,6 +225,16 @@ $xml = omp_request("
 		<comment>$timestamp</comment>
 		<config id='$pol_id' />
 		<target id='$target_id' />
+		 <preferences>
+			 <preference>
+				 <scanner_name>max_checks</scanner_name>
+				 <value>$maxchecks</value>
+			 </preference>
+			 <preference>
+				 <scanner_name>max_hosts</scanner_name>
+				 <value>$maxhosts</value>
+			 </preference>
+		 </preferences>
 	</create_task>
 ");
 if ( $xml->{status} eq "201" ) {
@@ -365,6 +381,7 @@ Usage: scan     --workspace=<seccubus workspace> --scan=<seccubus scan>
 		        --policy=<OpenVAS Scan Config name> [--target=<OpenVAS target>]
 		        [--targetip=<IP(s) to scan>] [--portlist=<OpenVAS port listname>]
 		        [--portrange=<Port range(s) to scan>] [--sleep=<sleeptime>]
+		        [--maxchecks=<max checks>] [--maxhosts=<max hosts>]
 		        [--timeout=<timeout>] [--nodelete] [--verbose] [--quiet] [--help]
 
 --workspace (-ws) - Seccubus workspace the scan should be in
@@ -391,6 +408,10 @@ Usage: scan     --workspace=<seccubus workspace> --scan=<seccubus scan>
 --timeout         - # Seconds after which to abort a scan (optional,
 	                default=14400 (4 hours))
 --nodelete        - Don't erase temporary files
+--maxchecks       - The number of plugins that will run against each host at the
+                    same time (optional, default=4)
+--maxhosts        - The maximum number of hosts to test at the same time
+                    (optional, default=10)
 --verbose (-v)    - Be verbose during execution (repeat to increase verbosity)
 --quiet (-q)      - Don't print output
 --help (-h)       - Print this message

--- a/scanners/OpenVAS6/scan
+++ b/scanners/OpenVAS6/scan
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright 2017 Fabien Guillaume, Frank Breedijk, Andrey Danin, Floris Kraak, Alireza Karbasian, Bernd Leinfelder
+# Copyright 2017-2019 Fabien Guillaume, Frank Breedijk, Andrey Danin, Floris Kraak, Alireza Karbasian, Bernd Leinfelder
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scanners/OpenVAS6/scan
+++ b/scanners/OpenVAS6/scan
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright 2017 Fabien Guillaume, Frank Breedijk, Andrey Danin, Floris Kraak, Alireza Karbasian
+# Copyright 2017 Fabien Guillaume, Frank Breedijk, Andrey Danin, Floris Kraak, Alireza Karbasian, Bernd Leinfelder
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Hey guys,

I needed to define limits for the OpenVAS scanner, so that a scan would not overload the poor servers. So I added the options --maxchecks and --maxhosts to the scan interface for OpenVAS. 

max_hosts
is maximum number of hosts to test at the same time which should be given to the client (which can override it). This value must be computed given your bandwidth, the number of hosts you want to test, your amount of memory and the horsepower of your processor(s).

max_checks
is the number of plugins that will run against each host being tested. Note that the total number of process will be max_checks x max_hosts so you need to find a balance between these two options. Note that launching too many plugins at the same time may disable the remote host, either temporarily (ie: inetd closes its ports) or definitely (the remote host crash because it is asked to do too many things at the same time), so be careful.

Hope this helps,

Bernd